### PR TITLE
Update Composer PHP version to support ^7.0 and ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
 "require": {
-    "php": "^7.0"
+    "php": "^7.0|^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0"


### PR DESCRIPTION
As PHP 8.0+ is backwards compatible with PHP 7.0+ functionality, this will help with projects running PHP 8.0+ who would like to use this package.

Any questions, please give me a shout!